### PR TITLE
Convert model2smtlib to funman subpackage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,27 +55,14 @@ RUN git clone --depth=1 https://github.com/danbryce/automates.git automates \
     && git fetch --depth=1 origin e5fb635757aa57007615a75371f55dd4a24851e0 \
     && git checkout e5fb635757aa57007615a75371f55dd4a24851e0
 RUN pip install -e automates
-# RUN pip install --no-cache-dir https://github.com/ml4ai/automates/archive/v1.3.0.zip
-# RUN pip install https://github.com/danbryce/automates/archive/e5fb635757aa57007615a75371f55dd4a24851e0.zip
 
 RUN pip install --no-cache-dir z3-solver
 RUN pip install --no-cache-dir graphviz
 
 # Install funman dev packages
-COPY --chown=$UID:$GID ./model2smtlib model2smtlib
-RUN pip install -e model2smtlib
-# RUN --mount=type=bind,source=./model2smtlib,target=/model2smtlib,rw \
-#     pip install -e /model2smtlib
-
-COPY --chown=$UID:$GID ./funman funman
+COPY --chown=$UID:$GID . funman
 RUN pip install -e funman
-# RUN --mount=type=bind,source=./funman,target=/funman,rw \
-#     pip install -e /funman
-
 RUN pip install -e funman/auxiliary_packages/funman_demo
-# RUN --mount=type=bind,source=./funman,target=/funman,rw \
-#     pip install -e /funman/auxiliary_packages/funman_demo
-
 RUN pip install -e funman/auxiliary_packages/funman_dreal
 
 WORKDIR /home/$UNAME/funman

--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -1,10 +1,22 @@
 # Assumes running from ASKEM/code
 *
 
-!funman
-!model2smtlib
+!LICENSE
+!Makefile
+!README.md
+!auxiliary_packages
+!docs
+!notebooks
+!pyproject.toml
+!resources
+!scratch
+!setup.py
+!src
+!test
 
 **/.*
 **/build
 **/dist
+
 !**/.git*
+

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ build-docker: build-docker-dreal
 		--build-arg UNAME=$$USER \
 		--build-arg UID=$$(id -u) \
 		--build-arg GID=$$(id -g) \
-		-t funman -f ./Dockerfile ..
+		-t funman -f ./Dockerfile .
 
 run-docker:
 	docker run \
@@ -80,7 +80,6 @@ run-docker:
 		--cpus=8 \
 		--name funman \
                 -p 8888:8888 \
-		-v $$PWD/../model2smtlib:/home/$$USER/model2smtlib \
 		-v $$PWD:/home/$$USER/funman \
 		funman:latest
 
@@ -92,7 +91,6 @@ run-podman:
 		--name funman \
 		--user $$USER \
 		-p 127.0.0.1:8888:8888 \
-		-v $$PWD/../model2smtlib:/home/$$USER/model2smtlib \
 		-v $$PWD:/home/$$USER/funman \
 		--userns=keep-id \
 		funman:latest
@@ -105,7 +103,6 @@ run-podman-notebook:
 		--name funman-notebook \
 		--user $$USER \
 		-p 127.0.0.1:8888:8888 \
-		-v $$PWD/../model2smtlib:/home/$$USER/model2smtlib \
 		-v $$PWD:/home/$$USER/funman \
 		--userns=keep-id \
 		funman:latest \
@@ -117,7 +114,7 @@ build-docker-dev:
 		--build-arg UNAME=$$USER \
 		--build-arg UID=$$(id -u) \
 		--build-arg GID=$$(id -g) \
-		-t funman-dev -f ./Dockerfile.dev ..
+		-t funman-dev -f ./Dockerfile.dev .
 
 rm-docker-dev-container:
 	docker rm funman-dev || echo "" > /dev/null

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ name = "pypi"
 
 [packages]
 automates = {editable = true, ref = "e5fb635757aa57007615a75371f55dd4a24851e0", git = "https://github.com/danbryce/automates.git"}
-model2smtlib = {editable = true, path = "./../model2smtlib"}
 funman = {editable = true, path = "."}
 funman_demo = {editable = true, path = "./auxiliary_packages/funman_demo"}
 funman_dreal = {editable = true, path = "./auxiliary_packages/funman_dreal"}

--- a/auxiliary_packages/funman_demo/src/funman_demo/example/bilayer.py
+++ b/auxiliary_packages/funman_demo/src/funman_demo/example/bilayer.py
@@ -6,13 +6,13 @@ from funman_demo.handlers import (
     RealtimeResultPlotter,
     ResultCacheWriter,
 )
-from model2smtlib.bilayer.translate import (
-    BilayerEncoder,
-    BilayerEncodingOptions,
-)
 
 from funman import Funman
 from funman.model import Parameter, QueryLE, QueryTrue
+from funman.model2smtlib.bilayer.translate import (
+    BilayerEncoder,
+    BilayerEncodingOptions,
+)
 from funman.model.bilayer import Bilayer, BilayerMeasurement, BilayerModel
 from funman.scenario.consistency import ConsistencyScenario
 from funman.scenario.parameter_synthesis import ParameterSynthesisScenario

--- a/auxiliary_packages/funman_demo/src/funman_demo/example/demo120822.py
+++ b/auxiliary_packages/funman_demo/src/funman_demo/example/demo120822.py
@@ -10,13 +10,13 @@ from funman_demo.handlers import (
 )
 from IPython.display import Markdown as md
 from matplotlib.ticker import FormatStrFormatter
-from model2smtlib.bilayer.translate import (
-    BilayerEncoder,
-    BilayerEncodingOptions,
-)
 
 from funman import Funman
 from funman.model import Parameter, QueryLE, QueryTrue
+from funman.model2smtlib.bilayer.translate import (
+    BilayerEncoder,
+    BilayerEncodingOptions,
+)
 from funman.model.bilayer import Bilayer, BilayerMeasurement, BilayerModel
 from funman.scenario.consistency import ConsistencyScenario
 from funman.scenario.parameter_synthesis import ParameterSynthesisScenario

--- a/notebooks/2022-09-14-demo.ipynb
+++ b/notebooks/2022-09-14-demo.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "# standard imports\n",
     "from funman.parameter_space import ParameterSpace\n",
-    "from model2smtlib.gromet.translate import QueryableGromet, QueryableBilayer\n",
+    "from funman.model2smtlib.gromet.translate import QueryableGromet, QueryableBilayer\n",
     "\n",
     "from pysmt.shortcuts import get_model, And, Symbol, FunctionType, Function, Equals, Int, Real, substitute, TRUE, FALSE, Iff, Plus, ForAll, LT, simplify\n",
     "from pysmt.typing import INT, REAL, BOOL\n",

--- a/notebooks/nov_30_2022_demo_funman.ipynb
+++ b/notebooks/nov_30_2022_demo_funman.ipynb
@@ -40,7 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from model2smtlib.bilayer.translate import BilayerEncoder, BilayerEncodingOptions\n",
+    "from funman.model2smtlib.bilayer.translate import BilayerEncoder, BilayerEncodingOptions\n",
     "from funman.scenario.consistency import ConsistencyScenario\n",
     "from funman.scenario.parameter_synthesis import ParameterSynthesisScenario\n",
     "from funman import Funman\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ build-backend = "setuptools.build_meta"
 addopts = [
     "--import-mode=importlib",
     "--cov=funman",
-    "--cov=model2smtlib",
     "--cov-report=xml",
     "--cov-report=term"
 ]

--- a/scratch/CHIME/test_CHIME_SIR.py
+++ b/scratch/CHIME/test_CHIME_SIR.py
@@ -2,7 +2,8 @@ import os
 import unittest
 
 from funman_demo.CHIME.CHIME_SIR import main as run_CHIME_SIR
-from model2smtlib.gromet.translate import QueryableGromet
+
+from funman.model2smtlib.gromet.translate import QueryableGromet
 
 RESOURCES = os.path.join("resources")
 GROMET_FILE = os.path.join(

--- a/scratch/CHIME/test_CHIME_parameter_synthesis.py
+++ b/scratch/CHIME/test_CHIME_parameter_synthesis.py
@@ -2,8 +2,7 @@ import os
 import unittest
 from multiprocessing.heap import Arena
 
-from model2smtlib.gromet.translate import QueryableGromet
-
+from funman.model2smtlib.gromet.translate import QueryableGromet
 from funman.parameter_space import ParameterSpace
 
 RESOURCES = os.path.join("resources")

--- a/scratch/CHIME/test_cached_parameter_space.py
+++ b/scratch/CHIME/test_cached_parameter_space.py
@@ -2,11 +2,11 @@ import os
 import unittest
 
 from funman_demo.handlers import RealtimeResultPlotter, ResultCacheWriter
-from model2smtlib.chime.translate import ChimeEncoder
 
 from funman import Funman
 from funman.examples.chime import CHIME
 from funman.model import Parameter, QueryLE
+from funman.model2smtlib.chime.translate import ChimeEncoder
 from funman.model.chime import ChimeModel
 from funman.scenario.parameter_synthesis import (
     ParameterSynthesisScenario,

--- a/scratch/CHIME/test_chime_param_synth_oct22_demo.py
+++ b/scratch/CHIME/test_chime_param_synth_oct22_demo.py
@@ -3,11 +3,11 @@ import tempfile
 import unittest
 
 from funman_demo.handlers import ResultCacheWriter
-from model2smtlib.chime.translate import ChimeEncoder
 
 from funman import Funman
 from funman.examples.chime import CHIME
 from funman.model import Model, Parameter, QueryLE
+from funman.model2smtlib.chime.translate import ChimeEncoder
 from funman.model.chime import ChimeModel
 from funman.scenario.parameter_synthesis import (
     ParameterSynthesisScenario,

--- a/scratch/model2smtlib/test_fn2smt.py
+++ b/scratch/model2smtlib/test_fn2smt.py
@@ -1,0 +1,30 @@
+import os
+import unittest
+
+from pysmt.shortcuts import Symbol, get_model
+from pysmt.typing import INT
+
+from funman.model2smtlib.gromet.translate import QueryableGromet
+
+RESOURCES = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "../resources"
+)
+
+
+class TestCompilation(unittest.TestCase):
+    def test_gromet_to_smt1(self):
+        """Encoding for `x = 2`"""
+        gFile = os.path.join(RESOURCES, "gromet", "exp0--Gromet-FN-auto.json")
+
+        fn = QueryableGromet.from_gromet_file(gFile)
+        print(fn._gromet_fn)
+        phi = fn.to_smtlib()
+        model = get_model(phi)
+        assert model  # Is phi satisfiable?
+        assert (
+            model.get_py_value(Symbol("exp0.fn.x", INT)) == 2
+        )  # Did the model get the right assignment?
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scratch/model2smtlib/test_parseGroMEtJSON.py
+++ b/scratch/model2smtlib/test_parseGroMEtJSON.py
@@ -1,0 +1,20 @@
+import os
+import unittest
+
+from funman.model2smtlib.gromet.translate import QueryableGromet
+
+RESOURCES = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "../resources"
+)
+
+
+class TestCompilation(unittest.TestCase):
+    def test_parseGroMEt(self):
+        gFile = os.path.join(
+            RESOURCES, "gromet", "CHIME_SIR_while_loop--Gromet-FN-auto.json"
+        )
+        fn = QueryableGromet.from_gromet_file(gFile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scratch/model2smtlib/test_read_bilayer.py
+++ b/scratch/model2smtlib/test_read_bilayer.py
@@ -1,0 +1,25 @@
+import os
+import unittest
+
+from funman.model2smtlib.bilayer.translate import Bilayer
+
+DATA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data")
+
+
+class TestCompilation(unittest.TestCase):
+    def test_read_bilayer(self):
+        bilayer_json_file = os.path.join(
+            DATA, "CHIME_SIR_dynamics_BiLayer.json"
+        )
+        bilayer = Bilayer.from_json(bilayer_json_file)
+        assert bilayer
+
+        #        encoding = bilayer.to_smtlib_timepoint(2) ## encoding at the single timepoint 2
+        encoding = bilayer.to_smtlib(
+            [2.5, 3, 4, 6]
+        )  ## encoding at the list of timepoints [2,3]
+        assert encoding
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scratch/model2smtlib/test_serialize_to_smt2.py
+++ b/scratch/model2smtlib/test_serialize_to_smt2.py
@@ -1,0 +1,36 @@
+import unittest
+
+from pysmt.shortcuts import GT, And, Int, Or, Solver, Symbol
+from pysmt.solvers.z3 import Z3Solver
+from pysmt.typing import BOOL, INT
+
+
+class TestSerializeToSMT2(unittest.TestCase):
+    """
+    Test Serialization to SMT2
+    """
+
+    def test_serialize_to_smt2(self):
+        """
+        NOTE This only works with the Z3 solver for the moment.
+
+        pysmt does not _seem_ to have a well defined 'to_smt2' function
+        defined within its standard API so I had to delve into the Z3 API to
+        get access to something that does a complete SMT2 serialization.
+
+        There is at least a .serialize() behavior available at the pysmt level.
+        Combining it will some processing of the current state of the solver
+        may allow for a general SMT2 serialization function. For now I am just
+        falling back to Z3.
+        """
+        solver: Z3Solver
+        with Solver(name="z3") as solver:
+            a = Symbol("A", BOOL)
+            b = Symbol("B", BOOL)
+            c = Symbol("C", INT)
+            solver.add_assertion(Or([And([a, b]), GT(c, Int(5))]))
+            print(solver.z3.to_smt2())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scratch/test_chime_bilayer_solve.py
+++ b/scratch/test_chime_bilayer_solve.py
@@ -6,13 +6,6 @@ import unittest
 import matplotlib.pyplot as plt
 import pandas as pd
 from funman_demo.handlers import RealtimeResultPlotter, ResultCacheWriter
-from model2smtlib.bilayer.translate import (
-    Bilayer,
-    BilayerEncoder,
-    BilayerEncodingOptions,
-    BilayerMeasurement,
-    BilayerModel,
-)
 from pysmt.shortcuts import (
     FALSE,
     GE,
@@ -38,6 +31,13 @@ from pysmt.typing import BOOL, INT, REAL
 
 from funman import Funman
 from funman.model import Model, Parameter, QueryLE
+from funman.model2smtlib.bilayer.translate import (
+    Bilayer,
+    BilayerEncoder,
+    BilayerEncodingOptions,
+    BilayerMeasurement,
+    BilayerModel,
+)
 from funman.scenario.consistency import ConsistencyScenario
 from funman.scenario.parameter_synthesis import ParameterSynthesisScenario
 from funman.search import BoxSearch, SearchConfig, SMTCheck

--- a/scratch/test_chime_bilayer_synth_to_consistency.py
+++ b/scratch/test_chime_bilayer_synth_to_consistency.py
@@ -4,16 +4,16 @@ import tempfile
 import unittest
 
 from funman_demo.handlers import RealtimeResultPlotter, ResultCacheWriter
-from model2smtlib.bilayer.translate import (
+
+from funman import Funman
+from funman.model import Parameter, QueryLE
+from funman.model2smtlib.bilayer.translate import (
     Bilayer,
     BilayerEncoder,
     BilayerEncodingOptions,
     BilayerMeasurement,
     BilayerModel,
 )
-
-from funman import Funman
-from funman.model import Parameter, QueryLE
 from funman.scenario.parameter_synthesis import (
     ParameterSynthesisScenario,
     ParameterSynthesisScenarioResult,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     install_requires=[
         "funman_dreal",
         "graphviz",
-        "model2smtlib",
         "multiprocess",
         "tenacity",
         "pyparsing",

--- a/src/funman/model/encoded.py
+++ b/src/funman/model/encoded.py
@@ -1,6 +1,5 @@
-from model2smtlib.translate import Encoding
-
 from funman.model import Model
+from funman.model2smtlib.translate import Encoding
 
 
 class EncodedModel(Model):

--- a/src/funman/model2smtlib/__init__.py
+++ b/src/funman/model2smtlib/__init__.py
@@ -1,0 +1,2 @@
+class QueryableModel(object):
+    pass

--- a/src/funman/model2smtlib/_version.py
+++ b/src/funman/model2smtlib/_version.py
@@ -1,0 +1,4 @@
+"""Version information."""
+
+# The following line *must* be the last in the module, exactly as formatted:
+__version__ = "1.2.0"

--- a/src/funman/model2smtlib/bilayer/translate.py
+++ b/src/funman/model2smtlib/bilayer/translate.py
@@ -1,0 +1,253 @@
+import logging
+from typing import Dict, List, Union
+
+import pysmt
+from pysmt.shortcuts import (
+    FALSE,
+    GE,
+    GT,
+    LE,
+    LT,
+    TRUE,
+    And,
+    Equals,
+    ForAll,
+    Function,
+    FunctionType,
+    Iff,
+    Int,
+    Plus,
+    Real,
+    Symbol,
+    Times,
+    get_model,
+    simplify,
+    substitute,
+)
+from pysmt.typing import BOOL, INT, REAL
+
+from funman.model import Model, Parameter, QueryLE, QueryTrue
+from funman.model2smtlib import QueryableModel
+from funman.model2smtlib.translate import Encoder, Encoding, EncodingOptions
+from funman.model.bilayer import Bilayer, BilayerMeasurement, BilayerModel
+from funman.search_utils import Box
+
+l = logging.Logger(__name__)
+
+
+class QueryableBilayer(QueryableModel):
+    def __init__(self):
+        pass
+
+    # STUB This is where we will read in and process the bilayer file
+    def query(query_str):
+        return False
+
+    # STUB Read the bilayer file into some object
+    @staticmethod
+    def from_bilayer_file(bilayer_path):
+
+        return QueryableBilayer(Bilayer.from_json(bilayer_path))
+
+
+class BilayerEncodingOptions(EncodingOptions):
+    def __init__(self, step_size=1, max_steps=2) -> None:
+        super().__init__(max_steps)
+        self.step_size = step_size
+        self.max_steps = max_steps
+
+
+class BilayerEncoder(Encoder):
+    def __init__(
+        self, config: BilayerEncodingOptions = BilayerEncodingOptions()
+    ) -> None:
+        super().__init__(config)
+
+    def encode_model(self, model: BilayerModel):
+        state_timepoints = range(
+            0,
+            self.config.max_steps + 1,
+            self.config.step_size,
+        )
+
+        if len(list(state_timepoints)) == 0:
+            raise Exception(
+                f"Could not identify timepoints from step_size = {self.config.step_size} and max_steps = {self.config.max_steps}"
+            )
+
+        transition_timepoints = range(
+            0, self.config.max_steps, self.config.step_size
+        )
+
+        init = And(
+            [
+                Equals(
+                    node.to_smtlib(0), Real(model.init_values[node.parameter])
+                )
+                for idx, node in model.bilayer.state.items()
+            ]
+        )
+
+        encoding = model.bilayer.to_smtlib(state_timepoints)
+
+        if model.parameter_bounds:
+            parameters = [
+                Parameter(
+                    node.parameter,
+                    lb=model.parameter_bounds[node.parameter][0],
+                    ub=model.parameter_bounds[node.parameter][1],
+                )
+                for _, node in model.bilayer.flux.items()
+                if node.parameter in model.parameter_bounds
+                and model.parameter_bounds[node.parameter]
+            ] + [
+                Parameter(
+                    node.parameter,
+                    lb=model.parameter_bounds[node.parameter][0],
+                    ub=model.parameter_bounds[node.parameter][1],
+                )
+                for _, node in model.measurements.flux.items()
+                if node.parameter in model.parameter_bounds
+                and model.parameter_bounds[node.parameter]
+            ]
+
+            timed_parameters = [
+                p.timed_copy(timepoint)
+                for p in parameters
+                for timepoint in transition_timepoints
+            ]
+            parameter_box = Box(timed_parameters)
+            parameter_constraints = parameter_box.to_smt(
+                closed_upper_bound=True
+            )
+        else:
+            parameter_constraints = TRUE()
+
+        measurements = self._encode_measurements(
+            model.measurements, state_timepoints
+        )
+
+        ## Assume that all parameters are constant
+        parameter_constraints = And(
+            parameter_constraints,
+            self._set_parameters_constant(
+                [v.parameter for v in model.bilayer.flux.values()], encoding
+            ),
+            self._set_parameters_constant(
+                [v.parameter for v in model.measurements.flux.values()],
+                measurements,
+            ),
+        )
+
+        formula = And(init, parameter_constraints, encoding, measurements)
+        symbols = self._symbols(formula)
+        return Encoding(formula=formula, symbols=symbols)
+
+    def _encode_measurements(
+        self, measurements: BilayerMeasurement, timepoints
+    ):
+        ans = And(
+            [
+                self._encode_measurements_timepoint(
+                    measurements, timepoints[i]
+                )
+                for i in range(len(timepoints))
+            ]
+        )
+        return ans
+
+    def _encode_measurements_timepoint(self, measurements, t):
+        observable_defs = And(
+            [
+                Equals(
+                    o.to_smtlib(t), self._observable_defn(measurements, o, t)
+                )
+                for o in measurements.observable.values()
+            ]
+        )
+        return observable_defs
+
+    def _observable_defn(self, measurements, obs, t):
+        # flux * incoming1 * incoming2 ...
+        obs_in_edges = measurements.node_incoming_edges[obs]
+        result = Real(0.0)
+        for src in obs_in_edges:
+            # src is a flux
+            f_t = src.to_smtlib(t)
+            src_srcs = [
+                s.to_smtlib(t) for s in measurements.node_incoming_edges[src]
+            ]
+            result = Plus(result, Times([f_t] + src_srcs)).simplify()
+        # flux = next([measurements.output_edges])
+        return result
+
+    def _set_parameters_constant(self, parameters, formula):
+        params = {
+            parameter: Symbol(parameter, REAL) for parameter in parameters
+        }
+        # print(formula)
+        symbols = self._symbols(formula)
+        all_equal = And(
+            [
+                And([Equals(params[p], s) for t, s in symbols[p].items()])
+                for p in params
+            ]
+        )
+        return all_equal
+
+    def _split_symbol(self, symbol):
+        if "_" in symbol.symbol_name():
+            return symbol.symbol_name().rsplit("_", 1)
+        else:
+            return symbol.symbol_name(), None
+
+    def symbol_values(self, model_encoding, pysmtModel):
+        vars = model_encoding.symbols
+        vals = {}
+        for var in vars:
+            vals[var] = {}
+            for t in vars[var]:
+                try:
+                    symbol = vars[var][t]
+                    vals[var][t] = float(pysmtModel.get_py_value(symbol))
+                except OverflowError as e:
+                    l.warn(e)
+        return vals
+
+    def parameter_values(
+        self, model, pysmtModel: pysmt.solvers.solver.Model
+    ) -> Dict[str, List[Union[float, None]]]:
+        try:
+            parameters = {
+                node.parameter: pysmtModel[Symbol(node.parameter, REAL)]
+                for _, node in model.bilayer.flux.items()
+            }
+            return parameters
+        except OverflowError as e:
+            l.warn(e)
+            return {}
+
+    def symbol_timeseries(
+        self, model_encoding, pysmtModel: pysmt.solvers.solver.Model
+    ) -> Dict[str, List[Union[float, None]]]:
+        """
+        Generate a symbol (str) to timeseries (list) of values
+
+        Parameters
+        ----------
+        pysmtModel : pysmt.solvers.solver.Model
+            variable assignment
+        """
+        series = self.symbol_values(model_encoding, pysmtModel)
+        a_series = {}  # timeseries as array/list
+        max_t = max(
+            [max([int(k) for k in tps.keys()]) for _, tps in series.items()]
+        )
+        a_series["index"] = list(range(0, max_t + 1))
+        for var, tps in series.items():
+
+            vals = [None] * (int(max_t) + 1)
+            for t, v in tps.items():
+                vals[int(t)] = v
+            a_series[var] = vals
+        return a_series

--- a/src/funman/model2smtlib/chime/translate.py
+++ b/src/funman/model2smtlib/chime/translate.py
@@ -1,0 +1,158 @@
+import logging
+from typing import Dict, List, Union
+
+import pysmt
+from pysmt.shortcuts import (
+    FALSE,
+    GE,
+    GT,
+    LE,
+    LT,
+    TRUE,
+    And,
+    Equals,
+    ForAll,
+    Function,
+    FunctionType,
+    Iff,
+    Int,
+    Plus,
+    Real,
+    Symbol,
+    Times,
+    get_free_variables,
+    get_model,
+    simplify,
+    substitute,
+)
+from pysmt.typing import BOOL, INT, REAL
+
+from funman.model import Model, Parameter, QueryLE, QueryTrue
+from funman.model2smtlib import QueryableModel
+from funman.model2smtlib.translate import Encoder, Encoding, EncodingOptions
+from funman.model.bilayer import Bilayer, BilayerMeasurement, BilayerModel
+from funman.model.chime import ChimeModel
+from funman.search_utils import Box
+
+l = logging.Logger(__name__)
+
+
+class ChimeEncoder(Encoder):
+    def encode_model(self, model: ChimeModel):
+        epochs = model.config["epochs"]
+        population_size = model.config["population_size"]
+        infectious_days = model.config["infectious_days"]
+        # infected_threshold = config["infected_threhold"]
+        vars, model = model.chime.make_model(
+            epochs=epochs,
+            population_size=population_size,
+            infectious_days=infectious_days,
+            infected_threshold=0.1,
+            linearize=model.config.get("linearize", False),
+        )
+        (default_parameters, init, dynamics, query) = model
+
+        # Associate parameters with symbols in the model
+        # symbol_map = {
+        #     s.symbol_name(): s
+        #     for p in parameters
+        #     for s in get_free_variables(p)
+        # }
+        # for p in parameters:
+        #     if not p._symbol:
+        #         p._symbol = symbol_map[p.name]
+
+        # param_symbols = set({p.name for p in self.parameters})
+        # assigned_parameters = [
+        #     p
+        #     for p in parameters
+        #     if len(
+        #         set(
+        #             {q.symbol_name() for q in get_free_variables(p)}
+        #         ).intersection(param_symbols)
+        #     )
+        #     == 0
+        # ]
+
+        formula = And(
+            # And(assigned_parameters),
+            init,
+            (
+                And([And(layer) for step in dynamics for layer in step])
+                if isinstance(dynamics, list)
+                else dynamics
+            ),
+        )
+        symbols = self._symbols(formula)
+        return Encoding(formula=formula, symbols=symbols)
+
+    def _encode_measurements_timepoint(self, measurements, t):
+        observable_defs = And(
+            [
+                Equals(
+                    o.to_smtlib(t), self._observable_defn(measurements, o, t)
+                )
+                for o in measurements.observable.values()
+            ]
+        )
+        return observable_defs
+
+    def _observable_defn(self, measurements, obs, t):
+        # flux * incoming1 * incoming2 ...
+        obs_in_edges = measurements.node_incoming_edges[obs]
+        result = Real(0.0)
+        for src in obs_in_edges:
+            # src is a flux
+            f_t = src.to_smtlib(t)
+            src_srcs = [
+                s.to_smtlib(t) for s in measurements.node_incoming_edges[src]
+            ]
+            result = Plus(result, Times([f_t] + src_srcs)).simplify()
+        # flux = next([measurements.output_edges])
+        return result
+
+    def _set_parameters_constant(self, parameters, formula):
+        params = {
+            parameter: Symbol(parameter, REAL) for parameter in parameters
+        }
+
+        symbols = self._symbols(formula)
+        all_equal = And(
+            [
+                And([Equals(params[p], s) for t, s in symbols[p].items()])
+                for p in params
+            ]
+        )
+        return all_equal
+
+    def _split_symbol(self, symbol):
+        if "_" in symbol.symbol_name():
+            return symbol.symbol_name().rsplit("_", 1)
+        else:
+            return symbol.symbol_name(), None
+
+    def symbol_values(self, model_encoding, pysmtModel):
+        vars = model_encoding.symbols
+        vals = {}
+        for var in vars:
+            vals[var] = {}
+            for t in vars[var]:
+                try:
+                    symbol = vars[var][t]
+                    vals[var][t] = float(pysmtModel.get_py_value(symbol))
+                except OverflowError as e:
+                    l.warn(e)
+        return vals
+
+    def parameter_values(
+        self, model, pysmtModel: pysmt.solvers.solver.Model
+    ) -> Dict[str, List[Union[float, None]]]:
+        try:
+            parameters = {
+                node.parameter: pysmtModel[Symbol(node.parameter, REAL)]
+                for _, node in model.bilayer.flux.items()
+            }
+            return parameters
+        except OverflowError as e:
+            l.warn(e)
+            return {}

--- a/src/funman/model2smtlib/gromet/translate.py
+++ b/src/funman/model2smtlib/gromet/translate.py
@@ -1,0 +1,268 @@
+from automates.model_assembly.gromet.model.function_type import FunctionType
+from automates.model_assembly.gromet.model.gromet_box_function import (
+    GrometBoxFunction,
+)
+from automates.model_assembly.gromet.model.gromet_fn import GrometFN
+from automates.model_assembly.gromet.model.gromet_fn_module import (
+    GrometFNModule,
+)
+from automates.model_assembly.gromet.model.gromet_port import GrometPort
+from automates.model_assembly.gromet.model.literal_value import LiteralValue
+from automates.model_assembly.gromet.model.typed_value import TypedValue
+from automates.program_analysis.JSON2GroMEt.json2gromet import json_to_gromet
+from pysmt.shortcuts import (
+    FALSE,
+    LT,
+    TRUE,
+    And,
+    Equals,
+    ForAll,
+    Iff,
+    Int,
+    Or,
+    Plus,
+    Real,
+    Symbol,
+    get_model,
+    substitute,
+)
+from pysmt.typing import BOOL, INT, REAL
+
+from funman.model2smtlib import QueryableModel
+
+# TODO more descriptive name
+
+
+class QueryableGromet(QueryableModel):
+    def __init__(self, gromet_fn) -> None:
+        self._gromet_fn = gromet_fn
+        self.gromet_encoding_handlers = {
+            str(GrometFNModule): self._gromet_fnmodule_to_smtlib,
+            str(GrometFN): self._gromet_fn_to_smtlib,
+            str(TypedValue): self._gromet_typed_value_to_smtlib,
+            str(GrometPort): self._gromet_port_to_smtlib,
+            str(GrometBoxFunction): self._gromet_box_function_to_smtlib,
+            str(LiteralValue): self._gromet_literal_value_to_smtlib,
+        }
+
+    def to_smtlib(self):
+        """Convert the self._gromet_fn into a set of smtlib constraints.
+
+        Returns:
+            pysmt.Node: SMTLib object for constraints.
+        """
+        return self._to_smtlib(self._gromet_fn, stack=[])[0][1]
+
+    def _to_smtlib(self, node, stack=[]):
+        """Convert the node into a set of smtlib constraints.
+
+        Returns:
+            pysmt.Node: SMTLib object for constraints.
+        """
+        return self.gromet_encoding_handlers[str(node.__class__)](
+            node, stack=stack
+        )
+
+    def _get_stack_identifier(self, stack):
+        return ".".join([name for (name, x) in stack])
+
+    def _gromet_fnmodule_to_smtlib(self, node, stack=[]):
+        stack.append((node.name, node))
+        [(_, fn_constraints)] = self._to_smtlib(node.fn, stack=stack)
+        # attr_constraints = And([self._to_smtlib(attr, stack=node) for attr in node.attributes])
+        stack.pop()
+        return [([Symbol(node.name, INT)], fn_constraints)]
+
+    def _gromet_fn_to_smtlib(self, node, stack=[]):
+        """Convert a fn node into constraints.  The constraints state that:
+        - The function output (pof) is equal to the output of the box function (bf)
+
+        Args:
+            node (GrometFN): the function to encode
+            stack (GrometFNModule, optional): GrometFNModule defining node. Defaults to None.
+
+        Returns:
+            pysmt.Node: Constraints encoding node.
+        """
+        # fn.pof[i] = fn.bf[fn.pof[i].box-1]
+
+        stack.append(("fn", node))
+
+        # Each iteration of this loop will generate a symbol
+        # and an implementation for a box function output port (pof),
+        # which appear in outputs as pairs
+
+        outputs = []
+
+        for j, bf_decl in enumerate(node.bf):
+            # get all outputs for bf, store original index i
+            bf_pofs = [
+                (i, pof) for i, pof in enumerate(node.pof) if pof.box - 1 == j
+            ]
+
+            # get implementation for bf
+            if hasattr(bf_decl, "contents") and bf_decl.contents:
+                bf_impl = stack[0][1].attributes[bf_decl.contents - 1]
+            else:
+                bf_impl = bf_decl
+            stack.append((f"bf[{j}]", bf_impl))
+            [(bf_opo_symbols, phi_bf_impl)] = self._to_smtlib(
+                bf_impl, stack=stack
+            )
+            stack.pop()
+
+            # Bind the opo ports of the box function to the pofs of node
+            port_bindings = []
+            pof_symbols = []
+            for i, (i_orig, pof) in enumerate(bf_pofs):
+                # pof = bf.opo
+                stack.append((f"pof[{i_orig}]", pof))
+                [([pof_head], _)] = self._to_smtlib(pof, stack=stack)
+                stack.pop()
+
+                bf_opo = bf_opo_symbols[i]
+                phi_bind_pof_opo = Equals(pof_head, bf_opo)
+                port_bindings.append(phi_bind_pof_opo)
+
+                if hasattr(pof, "name") and pof.name:
+                    stack.append((f"{pof.name}", pof.name))
+                    pof_name = Symbol(self._get_stack_identifier(stack), INT)
+                    stack.pop()
+                    pof_name_pof_binding = Equals(pof_name, pof_head)
+                    port_bindings.append(pof_name_pof_binding)
+                    pof_symbols.append(
+                        pof_name
+                    )  # Use pof name if present for outside reference
+                else:
+                    pof_symbols.append(
+                        pof_head
+                    )  # Otherwise use pof sybmol for outside reference
+
+            phi = And(port_bindings + [phi_bf_impl])
+            # symbol = Symbol(self._get_stack_identifier(stack), INT)
+            outputs.append((pof_symbols, phi))
+
+        # TODO implement the case for inputs
+        inputs = []
+
+        # Each iteration of the following loop will generate a
+        # symbol and implementation for each outer output port (opo)
+        # in terms of the wires in wfopo.
+
+        opo_wires = []
+        if node.wfopo:
+            for i, wfopo in enumerate(node.wfopo):
+                source_opo = node.opo[wfopo.src - 1]
+                target_pof = node.pof[wfopo.tgt - 1]
+
+                stack.append((f"opo[{wfopo.src-1}]", source_opo))
+                source_symbol = Symbol(self._get_stack_identifier(stack), INT)
+                stack.pop()
+                stack.append((f"pof[{wfopo.tgt-1}]", target_pof))
+                target_symbol = Symbol(self._get_stack_identifier(stack), INT)
+                stack.pop()
+
+                phi = Equals(source_symbol, target_symbol)
+                opo_wires.append(([source_symbol], phi))
+
+        # TODO implement case for input wires
+        opi_wires = []
+
+        stack.pop()
+
+        # consolidate formulas for internals of function
+        # need opo and opi symbols for binding and the
+        # implementation of the internals
+        out_symbols = [s for (ss, _) in opo_wires for s in ss]
+        in_symbols = [s for (ss, _) in opi_wires for s in ss]
+        impl = And(
+            [imp for (_, imp) in outputs + inputs + opo_wires + opi_wires]
+        )
+
+        return [(out_symbols + in_symbols, impl)]
+
+    def _gromet_port_to_smtlib(self, node, stack=[]):
+        # stack.append((node.name, node))
+        name = self._get_stack_identifier(stack)
+        # stack.pop()
+        return [([Symbol(f"{name}", INT)], None)]
+
+    def _gromet_box_function_to_smtlib(self, node, stack=[]):
+        phi = None
+        if node.function_type == FunctionType.EXPRESSION:
+            function_node = stack[0][1].attributes[node.contents - 1]
+            stack.append((f"fn", function_node))
+            [(symbols, phi)] = self._to_smtlib(function_node, stack=stack)
+            stack.pop()
+        elif node.function_type == FunctionType.LITERAL:
+            function_node = node.value
+            stack.append((f"value", function_node))
+            [(symbols, phi)] = self._to_smtlib(function_node, stack=stack)
+            stack.pop()
+        else:
+            raise ValueError(
+                f"node.function_type = {node.function_type} is not supported."
+            )
+
+        return [(symbols, phi)]
+
+    def _gromet_typed_value_to_smtlib(self, node, stack=[]):
+        phi = None
+        if node.type == "FN":  # FIXME find def for the string
+            # define output ports
+            # map i/o ports
+            #  wfopo
+            stack.append((f"value", node.value))
+            [(symbols, phi)] = self._to_smtlib(node.value, stack=stack)
+            stack.pop()
+
+        return [(symbols, phi)]
+
+    def _gromet_literal_value_to_smtlib(self, node, stack=[]):
+        value_type = node.value_type
+        value = None
+        value_enum = None
+
+        if value_type == "Integer":
+            value = Int(node.value)
+            value_enum = INT
+        else:
+            raise ValueError(
+                f"literal_value of type {value_type} not supported."
+            )
+
+        literal = Symbol(f"{self._get_stack_identifier(stack)}", value_enum)
+        phi = Equals(literal, value)
+
+        return [([literal], phi)]
+
+    # STUB This is where we will read in an process the gromet file
+    def query(self, query_str):
+        return True
+
+    # STUB Return the GrometBox based on the name (or path?)
+    def get_box(self, name):
+        # placeholder direct access via attributes list
+        results = [
+            a for a in self._gromet_fn.attributes if a.value.b[0].name == name
+        ]
+        assert len(results) == 1
+        return results[0]
+
+    # STUB Substitute the GrometBox b_sub into b_org's position
+    def substitute_box(self, b_org, b_sub, in_place=False):
+        """
+        b_org:
+            the box to replace
+        b_sub:
+            the replacement box
+        in_place:
+            flag on whether or not to return a new object or edit the current
+        object in place.
+        """
+        return self
+
+    # STUB Read the gromet file into some object
+    @staticmethod
+    def from_gromet_file(gromet_path):
+        return QueryableGromet(json_to_gromet(gromet_path))

--- a/src/funman/model2smtlib/translate.py
+++ b/src/funman/model2smtlib/translate.py
@@ -1,0 +1,102 @@
+from typing import Dict, List, Union
+
+import pysmt
+from pysmt.shortcuts import (
+    FALSE,
+    GE,
+    GT,
+    LE,
+    LT,
+    TRUE,
+    And,
+    Equals,
+    ForAll,
+    Function,
+    FunctionType,
+    Iff,
+    Int,
+    Plus,
+    Real,
+    Symbol,
+    Times,
+    get_model,
+    simplify,
+    substitute,
+)
+
+from funman.model import QueryLE, QueryTrue
+
+
+class Encoding(object):
+    def __init__(self, formula=None, symbols=None) -> None:
+        self.formula = formula
+        self.symbols = symbols
+
+
+class EncodingOptions(object):
+    def __init__(self, max_steps=2) -> None:
+        self.max_steps = max_steps
+
+
+class Encoder(object):
+    def __init__(self, config: EncodingOptions = EncodingOptions()) -> None:
+        self.config = config
+
+    def _symbols(self, formula):
+        symbols = {}
+        vars = list(formula.get_free_variables())
+        # vars.sort(key=lambda x: x.symbol_name())
+        for var in vars:
+            var_name, timepoint = self._split_symbol(var)
+            if timepoint:
+                if var_name not in symbols:
+                    symbols[var_name] = {}
+                symbols[var_name][timepoint] = var
+        return symbols
+
+    def encode_query(self, model_encoding, query):
+        query_handlers = {
+            QueryLE: self._encode_query_le,
+            QueryTrue: self._encode_query_true,
+        }
+
+        if type(query) in query_handlers:
+            return query_handlers[type(query)](model_encoding, query)
+        else:
+            raise NotImplementedError(
+                f"Do not know how to encode query of type {type(query)}"
+            )
+
+    def _encode_query_le(self, model_encoding, query):
+        timepoints = model_encoding.symbols[query.variable]
+        return Encoding(
+            And([LE(s, Real(query.ub)) for s in timepoints.values()])
+        )
+
+    def _encode_query_true(self, model_encoding, query):
+        return Encoding(TRUE())
+
+    def symbol_timeseries(
+        self, model_encoding, pysmtModel: pysmt.solvers.solver.Model
+    ) -> Dict[str, List[Union[float, None]]]:
+        """
+        Generate a symbol (str) to timeseries (list) of values
+
+        Parameters
+        ----------
+        pysmtModel : pysmt.solvers.solver.Model
+            variable assignment
+        """
+        series = self.symbol_values(model_encoding, pysmtModel)
+        a_series = {}  # timeseries as array/list
+        max_t = max(
+            [max([int(k) for k in tps.keys()]) for _, tps in series.items()]
+        )
+        a_series["index"] = list(range(0, max_t + 1))
+        for var, tps in series.items():
+
+            vals = [None] * (int(max_t) + 1)
+            for t, v in tps.items():
+                vals[int(t)] = v
+            a_series[var] = vals
+        return a_series

--- a/test/test_toy_param_synth.py
+++ b/test/test_toy_param_synth.py
@@ -1,11 +1,11 @@
 import unittest
 
-from model2smtlib.translate import Encoder
 from pysmt.shortcuts import GE, LE, And, Real, Symbol
 from pysmt.typing import REAL
 
 from funman import Funman
 from funman.model import Parameter, QueryTrue
+from funman.model2smtlib.translate import Encoder
 from funman.model.encoded import EncodedModel
 from funman.scenario.parameter_synthesis import ParameterSynthesisScenario
 from funman.search_utils import SearchConfig


### PR DESCRIPTION
Closes #4 

Folds model2smtlib into funman as a subpackage and then updates any obvious refs to the old model2smtlib package to instead point to the funman.model2smtlib subpackage.