### PR TITLE
clean up dreal pysmt importing

### DIFF
--- a/auxiliary_packages/funman_demo/src/funman_demo/example/demo120822.py
+++ b/auxiliary_packages/funman_demo/src/funman_demo/example/demo120822.py
@@ -28,8 +28,6 @@ from funman.utils.search_utils import (
     SearchConfig,
 )
 
-# import funman_dreal # Needed to use dreal with pysmt
-
 
 class Scenario1(object):
     def __init__(

--- a/auxiliary_packages/funman_dreal/src/funman_dreal/__init__.py
+++ b/auxiliary_packages/funman_dreal/src/funman_dreal/__init__.py
@@ -1,5 +1,3 @@
-from funman_dreal.solver import add_dreal_to_pysmt
+from funman_dreal.solver import ensure_dreal_in_pysmt
 
 from ._version import __version__
-
-add_dreal_to_pysmt()  # Wire Dreal into pysmt

--- a/auxiliary_packages/funman_dreal/src/funman_dreal/solver.py
+++ b/auxiliary_packages/funman_dreal/src/funman_dreal/solver.py
@@ -97,6 +97,13 @@ def add_dreal_to_pysmt():
     env.factory.solver_preference_list.append(name)
 
 
+def ensure_dreal_in_pysmt():
+    try:
+        add_dreal_to_pysmt()
+    except SolverRedefinitionError:
+        pass
+
+
 class DReal(SmtLibSolver):
     LOGICS = [QF_NRA]
     OptionsClass = SmtLibOptions

--- a/auxiliary_packages/funman_dreal/test/test_solver.py
+++ b/auxiliary_packages/funman_dreal/test/test_solver.py
@@ -1,6 +1,6 @@
 import unittest
 
-import funman_dreal  # Needed to use dreal with pysmt
+import funman_dreal
 from pysmt.logics import QF_NRA
 from pysmt.shortcuts import (
     LE,
@@ -21,8 +21,8 @@ from pysmt.shortcuts import (
 
 class TestRunDrealNative(unittest.TestCase):
     def test_dreal(self):
-
-        # from dreal import *
+        # Needed to use dreal with pysmt
+        funman_dreal.ensure_dreal_in_pysmt()
 
         # x = Variable("x")
         # y = Variable("y")

--- a/src/funman/utils/search_utils.py
+++ b/src/funman/utils/search_utils.py
@@ -794,7 +794,14 @@ class SearchConfig(Config):
         self.search = search
         self.solver = solver
         if self.solver == "dreal":
-            import funman_dreal  # Needed to add dreal to pysmt solver list
+            try:
+                import funman_dreal
+            except:
+                raise Exception(
+                    "The funman_dreal package failed to import. Do you have it installed?"
+                )
+            else:
+                funman_dreal.ensure_dreal_in_pysmt()
 
 
 def _encode_labeled_box(box: Box, label: str):


### PR DESCRIPTION
Closes #10

Adjusts the dreal pysmt registration to be a call outside the import (to avoid surprises with seemingly unused by critical import calls).